### PR TITLE
Dropdown closing on focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@anypoint-web-components/anypoint-autocomplete",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anypoint-web-components/anypoint-autocomplete",
   "description": "Anypoint styled autocomplete for inputs.",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/test/anypoint-autocomplete.test.js
+++ b/test/anypoint-autocomplete.test.js
@@ -1444,4 +1444,39 @@ describe('<anypoint-autocomplete>', () => {
       assert.equal(result, 'listbox');
     });
   });
+
+  describe('Suggestion rendering', () => {
+    let element = /** @type AnypointAutocomplete */ (null);
+    let input = /** @type HTMLInputElement */ (null);
+
+    beforeEach(async () => {
+      const region = await suggestionsFixture();
+      element = region.querySelector('anypoint-autocomplete');
+      element.openOnFocus = true;
+      input = region.querySelector('input');
+      await nextFrame();
+    });
+
+    it('should open suggestions when input is focused', async () => {
+      input.focus();
+      await nextFrame();
+      assert.isTrue(element.opened);
+    });
+
+    it('should close suggestions when click happens outside input', async () => {
+      input.focus();
+      await nextFrame();
+      document.body.click();
+      await nextFrame();
+      assert.isFalse(element.opened);
+    });
+
+    it('should not close suggestions when click happens inside input', async () => {
+      input.focus();
+      await nextFrame();
+      input.click();
+      await nextFrame();
+      assert.isTrue(element.opened);
+    });
+  });
 });


### PR DESCRIPTION
- Disable auto closing from overlay mixin
- Manage close on outside click manually
- Prevent closing if the click is inside the `target`